### PR TITLE
ci: consolidate ruff lint steps via pre-commit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,11 +24,8 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras
 
-      - name: Ruff check
-        run: uv run ruff check src/ tests/
-
-      - name: Ruff format check
-        run: uv run ruff format --check src/ tests/
+      - name: Ruff (pre-commit)
+        run: uv run pre-commit run --all-files
 
       - name: Mypy type check
         run: uv run mypy src/shinkoku/ --ignore-missing-imports


### PR DESCRIPTION
## Summary
- Replace separate `ruff check` and `ruff format --check` CI steps with a single `pre-commit run --all-files` invocation
- Makes `.pre-commit-config.yaml` the single source of truth for ruff configuration in CI
- Mypy type check step remains unchanged as a separate step

## Test plan
- [ ] Verify `uv run pre-commit run --all-files` passes locally
- [ ] Verify CI lint job passes with the new pre-commit-based step
- [ ] Confirm mypy step still runs independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)