### PR TITLE
fix: migrate version field from marketplace.json to plugin.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,6 @@
       "name": "shinkoku",
       "source": "./",
       "description": "確定申告自動化 Claude Code Plugin。帳簿管理から e-Tax 入力代行まで。",
-      "version": "0.2.0",
       "license": "MIT"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "shinkoku",
+  "version": "0.3.0",
   "description": "確定申告を自動化する Claude Code Plugin。会社員＋副業（事業所得・青色申告）の所得税・消費税確定申告をエンドツーエンドで支援。",
   "author": {
     "name": "kazukinagata"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,25 +83,25 @@ jobs:
           echo "Source/skill changes detected:"
           echo "$CHANGED"
 
-          # marketplace.json のバージョンがベースから更新されているか
-          BASE_MKT_VER=$(git show "$BASE_SHA":.claude-plugin/marketplace.json | python3 -c "
+          # plugin.json のバージョンがベースから更新されているか
+          BASE_MKT_VER=$(git show "$BASE_SHA":.claude-plugin/plugin.json | python3 -c "
           import json, sys
           data = json.load(sys.stdin)
-          print(data['plugins'][0]['version'])
+          print(data['version'])
           ")
           HEAD_MKT_VER=$(python3 -c "
           import json
-          with open('.claude-plugin/marketplace.json') as f:
+          with open('.claude-plugin/plugin.json') as f:
               data = json.load(f)
-          print(data['plugins'][0]['version'])
+          print(data['version'])
           ")
 
           if [ "$BASE_MKT_VER" = "$HEAD_MKT_VER" ]; then
-            echo "::error::marketplace.json version ($HEAD_MKT_VER) was not updated. Bump the version when changing src/ or skills/."
+            echo "::error::plugin.json version ($HEAD_MKT_VER) was not updated. Bump the version when changing src/ or skills/."
             exit 1
           fi
 
-          # pyproject.toml と marketplace.json のバージョンが一致するか
+          # pyproject.toml と plugin.json のバージョンが一致するか
           PYPROJECT_VER=$(python3 -c "
           import re
           with open('pyproject.toml') as f:
@@ -113,7 +113,7 @@ jobs:
           ")
 
           if [ "$PYPROJECT_VER" != "$HEAD_MKT_VER" ]; then
-            echo "::error::Version mismatch: pyproject.toml=$PYPROJECT_VER, marketplace.json=$HEAD_MKT_VER. Keep them in sync."
+            echo "::error::Version mismatch: pyproject.toml=$PYPROJECT_VER, plugin.json=$HEAD_MKT_VER. Keep them in sync."
             exit 1
           fi
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,15 +178,15 @@ uv run shinkoku profile --config shinkoku.config.yaml
 **更新が必要なファイル（2箇所を同期）:**
 
 - `pyproject.toml` — `version` フィールド
-- `.claude-plugin/marketplace.json` — `plugins[0].version` フィールド
+- `.claude-plugin/plugin.json` — `version` フィールド
 
 **更新不要なファイル:**
 
-- `.claude-plugin/plugin.json` — version フィールドなし（marketplace.json に一元化）
+- `.claude-plugin/marketplace.json` — version フィールドなし（plugin.json に一元化）
 
 **CI による検証:**
 
-- PR で `src/shinkoku/` または `skills/` に変更がある場合、`marketplace.json` のバージョンがベースブランチから更新されていること、`pyproject.toml` と一致することを自動チェックする
+- PR で `src/shinkoku/` または `skills/` に変更がある場合、`plugin.json` のバージョンがベースブランチから更新されていること、`pyproject.toml` と一致することを自動チェックする
 - `tests/`・`.github/`・`*.md`・`Makefile` のみの変更ではバージョン更新不要
 
 ## DB 規約

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "shinkoku"
-version = "0.2.0"
+version = "0.3.0"
 description = "確定申告自動化 Claude Code Plugin"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -1186,7 +1186,7 @@ wheels = [
 
 [[package]]
 name = "shinkoku"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "pdfplumber" },


### PR DESCRIPTION
## Summary

- Cowork の更新ボタンで `marketplace.json` の version が反映されず 0.1.0 のままになる問題を修正
- `plugin.json` に `"version": "0.3.0"` を追加し、`marketplace.json` から version フィールドを削除
- CI の version-check ジョブを `plugin.json` 参照に変更
- `pyproject.toml` を 0.3.0 にバンプ
- `CLAUDE.md` のバージョン管理セクションを更新

## Test plan

- [x] `plugin.json` に `"version": "0.3.0"` が存在すること
- [x] `marketplace.json` から version が削除されていること
- [x] `pyproject.toml` が `version = "0.3.0"` であること
- [x] CI の version-check が `plugin.json` を参照していること
- [x] `CLAUDE.md` の記述が整合していること
- [x] `uv run pytest tests/ -v` で全 254 テスト通過
- [ ] Cowork で更新が 0.3.0 として検知されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)