### PR TITLE
fix: skip claude-review on fork PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,7 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    if: github.event.pull_request.head.repo.full_name == github.repository
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- fork PRs では GitHub のセキュリティ仕様によりシークレット・OIDC トークンにアクセスできないため、`claude-review` が必ず失敗していた
- `if: github.event.pull_request.head.repo.full_name == github.repository` を追加し、fork PRs ではジョブ自体をスキップするように変更

## 背景
- PR #23 (fork PR) で `claude-review` が OIDC エラーで失敗し続けていた
- 同一リポジトリからの PR #25 では正常に動作していることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)